### PR TITLE
fix: ensure nifti provider has higher priority

### DIFF
--- a/src/nifti/index.js
+++ b/src/nifti/index.js
@@ -124,7 +124,8 @@ const nifti = {
 
   register (cornerstone) {
     cornerstone.registerImageLoader('nifti', (imageId) => this.cornerstoneLoader(imageId, this));
-    cornerstone.metaData.addProvider(metaDataProvider);
+    // consider nifti provider to have higher priority (usually apps, as OHIF, has providers priority less than 9999)
+    cornerstone.metaData.addProvider(metaDataProvider, 10000);
   },
 
   configure (loaderOptions) {


### PR DESCRIPTION
### Includes
- Nifti provider should be always the first provider choice for nifti files (even if there is any other fallback provider)
- Apps, as OHIF, has providers with priority less than 9999