### PR TITLE
fix: invalid float values(IEEE-754) to be valid js values

### DIFF
--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -1,5 +1,6 @@
 import { external } from '../externalModules.js';
 import decodeNiFTIBigEndian from '../shared/niftiBigEndianDecoder.js';
+import normalizeInvalid from '../shared/normalizeInvalid.js';
 
 export function parseNiftiHeader (fileData) {
   const nifti = external.niftiReader;
@@ -65,7 +66,7 @@ export function parseNiftiFile (fileData, metaData) {
   const arraybuffer = nifti.readImage(metaData.header, fileData);
 
   // reads the image data using nifti-reader-js and puts it in a typed array
-  let imageData = new TypedArrayConstructor(arraybuffer);
+  let imageData = normalizeInvalid(metaData.header.datatypeCode, new TypedArrayConstructor(arraybuffer));
 
   if (!metaData.header.littleEndian) {
     imageData = decodeNiFTIBigEndian(metaData.header.datatypeCode, imageData);

--- a/src/shared/normalizeInvalid.js
+++ b/src/shared/normalizeInvalid.js
@@ -1,0 +1,43 @@
+import { external } from '../externalModules.js';
+
+const nifti = external.niftiReader;
+
+/**
+ * It will normalize NaN or (-)Infinity values to +MAX_VALUE, -MAX_VALUE or 0.
+ * It mutates given param
+ * 
+ * @param {TypedArray} imageData
+ * @return {TypedArray} Modified imageData
+ */
+const normalizeInvalidFloat = (imageData) => {
+  for (let it = 0; it < imageData.length; it++) {
+    if (isNaN(imageData[it])) {
+      // defaults to 0
+      imageData[it] = 0;
+    } else if (!isFinite(imageData[it])) {
+      // using the maximum/minimum value instead of infinity
+      imageData[it] = Math.sign(imageData[it]) * Number.MAX_VALUE;
+    }
+  }
+
+  return imageData;
+};
+
+/**
+ * Normalize invalid data. Applied to float data only
+ * It mutates given imageData
+ * @param {string} datatypeCode
+ * @param {TypedArray} imageData
+ * @return {TypedArray} normalized imageData
+ */
+export default function normalizeInvalid (datatypeCode, imageData) {
+
+  switch (datatypeCode) {
+  case nifti.NIFTI1.TYPE_FLOAT32:
+  case nifti.NIFTI1.TYPE_FLOAT64:
+    return normalizeInvalidFloat(imageData);
+  }
+
+  // return not normalized data
+  return imageData;
+}


### PR DESCRIPTION
It Includes
- Skip float invalid values (change it to valid js values)
- Applies to Float64Array and Float32Array and values NaN, -Infinity, +Infinity.
- Normalize it after data is decompressed