### PR TITLE
Resolve nifti crashes issue.

### DIFF
--- a/src/nifti/FileStreamer.js
+++ b/src/nifti/FileStreamer.js
@@ -40,7 +40,11 @@ export default class FileStreamer {
               total: contentLength
             }
           });
-          handleChunk(chunk, imageIdObject);
+          try {
+            handleChunk(chunk, imageIdObject);
+          } catch (error) {
+            reject(error);
+          }
         });
 
         response.on('end', () => {

--- a/src/nifti/VolumeAcquisitionStreamer.js
+++ b/src/nifti/VolumeAcquisitionStreamer.js
@@ -102,16 +102,20 @@ export default class VolumeAcquisitionStreamer {
       }
 
       const fetcher = fetcherData.volumeFetcher;
-      const fileFetchedPromise = fetcher.getHeaderPromise();
+       try {
+        const fileFetchedPromise = fetcher.getHeaderPromise();
 
-      fileFetchedPromise.
-        // creates the volume: metadata + image data
-        then((data) => this[createVolume](data, imageIdObject)).
-        // adds the volume to the cache
-        then((data) => this[cacheVolume](data, imageIdObject)).
-        // fulfills the volumeAcquiredPromise
-        then((data) => resolve(data)).
-        catch(reject);
+        fileFetchedPromise.
+          // creates the volume: metadata + image data
+          then((data) => this[createVolume](data, imageIdObject)).
+          // adds the volume to the cache
+          then((data) => this[cacheVolume](data, imageIdObject)).
+          // fulfills the volumeAcquiredPromise
+          then((data) => resolve(data)).
+          catch(reject);
+       } catch (error) {
+        reject(error);
+      }
     });
 
     // save this promise to the promise cache

--- a/src/nifti/VolumeTimepointFileFetcher.js
+++ b/src/nifti/VolumeTimepointFileFetcher.js
@@ -72,7 +72,7 @@ export default class VolumeTimepointFileFetcher {
   }
 
   static runStreamer (imageIdObject, imageData) {
-    imageData.streamer.stream(imageIdObject, (chunk) => {
+    return imageData.streamer.stream(imageIdObject, (chunk) => {
       if (!imageData.headerParsed) {
         if (!VolumeTimepointFileFetcher.tryParseHeader(imageData, chunk)) {
           return;
@@ -94,6 +94,9 @@ export default class VolumeTimepointFileFetcher {
       VolumeTimepointFileFetcher.addToImageDataBuffer(imageData, chunk);
 
       VolumeTimepointFileFetcher.evaluatePromises(imageData);
+    }).catch((error) => {
+      imageData.headerPromiseMethods.reject(error);
+      throw error;
     });
   }
 

--- a/src/nifti/index.js
+++ b/src/nifti/index.js
@@ -92,6 +92,8 @@ const nifti = {
           metaDataManager.add(imageIdObject.url, slice.compoundMetaData);
 
           return slice.compoundMetaData;
+        }).catch((error) => {
+          throw error;
         });
 
     } catch (error) {

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -174,7 +174,9 @@ function niftiDatatypeCodeToTypedArray (nifti, datatypeCode) {
     [nifti.NIFTI1.TYPE_RGB]: Uint8Array,
     [nifti.NIFTI1.TYPE_RGBA]: Uint8Array
   };
-
+  if (!typedArrayConstructorMap.hasOwnProperty(datatypeCode)) {
+    throw new Error(`Could not parse NIfTI file. Datatype Code (${datatypeCode}) is not supported for this image.`);
+  }
   return typedArrayConstructorMap[datatypeCode];
 }
 


### PR DESCRIPTION
Allow consumers to retrieve actual error and handle accordingly. Do not hide errors occured while loading.