### PR TITLE
Unable to load a minimal-sized NIFTI file.

### DIFF
--- a/src/nifti/VolumeTimepointFileFetcher.js
+++ b/src/nifti/VolumeTimepointFileFetcher.js
@@ -223,15 +223,6 @@ export default class VolumeTimepointFileFetcher {
 
       return canParse;
     }
-
-    if (imageData.tmpBuffer.length + chunk.length < imageData.headerOffset) {
-      // we don't have enough data, lets add it and wait for next chunk
-      imageData.tmpBuffer = unInt8ArrayConcat(imageData.tmpBuffer, chunk);
-
-      return false;
-    }
-
-
     // we don't want to add the chunk now to tmpBuffer/buffer. This will be handlded by recursion
     let tempBuffer = unInt8ArrayConcat(imageData.tmpBuffer, chunk);
 
@@ -245,6 +236,12 @@ export default class VolumeTimepointFileFetcher {
       tempBuffer = inflator.result;
     }
 
+    if (tempBuffer.length < imageData.headerOffset) {
+      // we don't have enough data, lets add it and wait for next chunk
+      imageData.tmpBuffer = unInt8ArrayConcat(imageData.tmpBuffer, chunk);
+
+      return false;
+    }
     const rawData = new DataView(tempBuffer.buffer);
     let littleEndian = false;
     const magicCookieVal = niftiReader.Utils.getIntAt(rawData, 0, littleEndian);


### PR DESCRIPTION
**Issue** : Unable to load a minimal-sized NIFTI file.

**Fix** : The reason for this is that, when compressing data `imageData` may not be as large as the `headerOffset` value for imageData. 
If we compare the length of imageData with headerOffset, it will be less and will consider it to have insufficient data. 
As a result, it will wait for the next chunk and return which keeps it waiting.

As a solution, we changed the order of finding `pako inflators` and compared that result with the headoffset.