### PR TITLE
Update for serving the image plane meta data and original header information consistently on on each request

### DIFF
--- a/src/nifti/VolumeAcquisitionStreamer.js
+++ b/src/nifti/VolumeAcquisitionStreamer.js
@@ -86,8 +86,10 @@ export default class VolumeAcquisitionStreamer {
   acquireHeaderOnly (imageIdObject, isRangeRead = true) {
     const fetcherData = this.getFetcherData(imageIdObject);
 
-    if (fetcherData.headerPromise) {
-      return fetcherData.headerPromise;
+    const headerPromise = fetcherData.headerPromise || fetcherData.headerOnlyPromise;
+
+    if (headerPromise) {
+      return headerPromise;
     }
 
     // if no one has requested the header of this volume yet, we create a

--- a/src/nifti/VolumeAcquisitionStreamer.js
+++ b/src/nifti/VolumeAcquisitionStreamer.js
@@ -43,11 +43,12 @@ export default class VolumeAcquisitionStreamer {
   acquireTimepoint (imageIdObject) {
 
     // if we have the timepoint already generated, return it immediately.
-    const cachedVolume = this.volumeCache.get(imageIdObject);
+    const cachedVolume = this.volumeCache.getTimepoint(imageIdObject, imageIdObject.timePoint);
 
     if (cachedVolume && cachedVolume.hasImageData) {
+      Promise.resolve(cachedVolume);
 
-      return Promise.resolve(cachedVolume);
+      return;
     }
 
     const fetcherData = this.getFetcherData(imageIdObject);
@@ -88,20 +89,20 @@ export default class VolumeAcquisitionStreamer {
     if (fetcherData.headerPromise) {
       return fetcherData.headerPromise;
     }
-    const cachedVolume = this.volumeCache.get(imageIdObject);
-
-    if (cachedVolume) {
-
-      return Promise.resolve(cachedVolume);
-    }
 
     // if no one has requested the header of this volume yet, we create a
     // promise to acquire it
     const volumeHeaderAcquiredPromise = new Promise((resolve, reject) => {
+      const cachedVolume = this.volumeCache.getTimepoint(imageIdObject, imageIdObject.timePoint);
+
+      if (cachedVolume) {
+        resolve(cachedVolume);
+
+        return;
+      }
 
       const fetcher = fetcherData.volumeFetcher;
-
-      try {
+       try {
         const fileFetchedPromise = fetcher.getHeaderPromise();
 
         fileFetchedPromise.
@@ -112,7 +113,7 @@ export default class VolumeAcquisitionStreamer {
           // fulfills the volumeAcquiredPromise
           then((data) => resolve(data)).
           catch(reject);
-      } catch (error) {
+       } catch (error) {
         reject(error);
       }
     });

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -1,7 +1,6 @@
 import { external } from '../externalModules.js';
 import decodeNiFTIBigEndian from '../shared/niftiBigEndianDecoder.js';
 import normalizeInvalid from '../shared/normalizeInvalid.js';
-import _ from 'lodash';
 
 export function parseNiftiHeader (fileData) {
   const nifti = external.niftiReader;
@@ -37,7 +36,7 @@ export function parseNiftiHeader (fileData) {
     isDataInColors: isDataInColors(nifti, header.dims, header.datatypeCode)
   };
   const pixelSpacing = header.pixDims.slice(1, 4);
-  const orientationMatrix = _.cloneDeep(getOrientationMatrix(header));
+  const orientationMatrix = getOrientationMatrix(header);
   const orientationString = header.convertNiftiSFormToNEMA(orientationMatrix);
 
   return {
@@ -128,7 +127,7 @@ function ensureUnitInMillimeters (nifti, header) {
 
 function getOrientationMatrix (header) {
   if (header.affine && header.sform_code > 0) {
-    return header.affine;
+    return header.affine.map((row) => row.slice());
   }
 
   if (header.qform_code > 0) {

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -127,7 +127,7 @@ function ensureUnitInMillimeters (nifti, header) {
 
 function getOrientationMatrix (header) {
   if (header.affine && header.sform_code > 0) {
-    return header.affine;
+    return header.affine.map((row) => row.slice());
   }
 
   if (header.qform_code > 0) {

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -1,6 +1,7 @@
 import { external } from '../externalModules.js';
 import decodeNiFTIBigEndian from '../shared/niftiBigEndianDecoder.js';
 import normalizeInvalid from '../shared/normalizeInvalid.js';
+import _ from 'lodash';
 
 export function parseNiftiHeader (fileData) {
   const nifti = external.niftiReader;
@@ -36,7 +37,7 @@ export function parseNiftiHeader (fileData) {
     isDataInColors: isDataInColors(nifti, header.dims, header.datatypeCode)
   };
   const pixelSpacing = header.pixDims.slice(1, 4);
-  const orientationMatrix = getOrientationMatrix(header);
+  const orientationMatrix = _.cloneDeep(getOrientationMatrix(header));
   const orientationString = header.convertNiftiSFormToNEMA(orientationMatrix);
 
   return {
@@ -127,7 +128,7 @@ function ensureUnitInMillimeters (nifti, header) {
 
 function getOrientationMatrix (header) {
   if (header.affine && header.sform_code > 0) {
-    return header.affine.map((row) => row.slice());
+    return header.affine;
   }
 
   if (header.qform_code > 0) {

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -1,7 +1,6 @@
 import { external } from '../externalModules.js';
 import decodeNiFTIBigEndian from '../shared/niftiBigEndianDecoder.js';
 import normalizeInvalid from '../shared/normalizeInvalid.js';
-import _ from 'lodash';
 
 export function parseNiftiHeader (fileData) {
   const nifti = external.niftiReader;
@@ -37,7 +36,7 @@ export function parseNiftiHeader (fileData) {
     isDataInColors: isDataInColors(nifti, header.dims, header.datatypeCode)
   };
   const pixelSpacing = header.pixDims.slice(1, 4);
-  const orientationMatrix = _.cloneDeep(getOrientationMatrix(header));
+  const orientationMatrix = getOrientationMatrix(header);
   const orientationString = header.convertNiftiSFormToNEMA(orientationMatrix);
 
   return {

--- a/src/nifti/parseNiftiFile.js
+++ b/src/nifti/parseNiftiFile.js
@@ -1,6 +1,7 @@
 import { external } from '../externalModules.js';
 import decodeNiFTIBigEndian from '../shared/niftiBigEndianDecoder.js';
 import normalizeInvalid from '../shared/normalizeInvalid.js';
+import _ from 'lodash';
 
 export function parseNiftiHeader (fileData) {
   const nifti = external.niftiReader;
@@ -36,7 +37,7 @@ export function parseNiftiHeader (fileData) {
     isDataInColors: isDataInColors(nifti, header.dims, header.datatypeCode)
   };
   const pixelSpacing = header.pixDims.slice(1, 4);
-  const orientationMatrix = getOrientationMatrix(header);
+  const orientationMatrix = _.cloneDeep(getOrientationMatrix(header));
   const orientationString = header.convertNiftiSFormToNEMA(orientationMatrix);
 
   return {


### PR DESCRIPTION
First change is related to the 'orientationMatrix' initialization. Currently the header affine matrix reference is directly use as orientation matrix and the same reference getting updated as part of conversion to the dicom's image orientation to match with cornerstone expectation, so a new copy used to initialize the orientation matrix while parsing nifti file.

Next change is related to the caching of the created volume. Currently the created volume is caching with the request file path as the key but the same is fetching using the file path and time point combination key. So, on each request the volume created again and the 'orientationMatrix' updated each time. This will result in different image plane meta data(image position, orientation) on each request.